### PR TITLE
Add WhatsApp notification

### DIFF
--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -23,6 +23,7 @@ export default function App() {
           Home
         </Link>
         <Link to="/app/additional">Additional page</Link>
+        <Link to="/app/settings">Settings</Link>
       </NavMenu>
       <Outlet />
     </AppProvider>

--- a/app/routes/app.settings.jsx
+++ b/app/routes/app.settings.jsx
@@ -1,0 +1,78 @@
+import { json, redirect } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+import {
+  Page,
+  Layout,
+  Card,
+  TextField,
+  InlineStack,
+  Button,
+  Checkbox,
+  BlockStack,
+} from "@shopify/polaris";
+import { TitleBar } from "@shopify/app-bridge-react";
+import prisma from "../db.server";
+import { authenticate } from "../shopify.server";
+
+export const loader = async ({ request }) => {
+  const { session } = await authenticate.admin(request);
+  const config = await prisma.whatsAppConfig.findUnique({
+    where: { shop: session.shop },
+  });
+  return json({ config });
+};
+
+export const action = async ({ request }) => {
+  const { session } = await authenticate.admin(request);
+  const form = await request.formData();
+  const phoneNumberId = form.get("phoneNumberId") || "";
+  const token = form.get("token") || "";
+  const enabled = form.get("enabled") === "on";
+  await prisma.whatsAppConfig.upsert({
+    where: { shop: session.shop },
+    update: { phoneNumberId, token, enabled },
+    create: { shop: session.shop, phoneNumberId, token, enabled },
+  });
+  return redirect("/app/settings");
+};
+
+export default function Settings() {
+  const { config } = useLoaderData();
+  return (
+    <Page>
+      <TitleBar title="WhatsApp settings" />
+      <Layout>
+        <Layout.Section>
+          <Card>
+            <Form method="post">
+              <BlockStack gap="400">
+                <TextField
+                  name="phoneNumberId"
+                  label="Phone number ID"
+                  defaultValue={config?.phoneNumberId || ""}
+                  autoComplete="off"
+                />
+                <TextField
+                  name="token"
+                  label="Access token"
+                  defaultValue={config?.token || ""}
+                  autoComplete="off"
+                />
+                <Checkbox
+                  label="Enable notifications"
+                  name="enabled"
+                  defaultChecked={config?.enabled}
+                />
+                <InlineStack>
+                  <Button submit primary>
+                    Save
+                  </Button>
+                </InlineStack>
+              </BlockStack>
+            </Form>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
+}

--- a/app/routes/webhooks.fulfillments_create.jsx
+++ b/app/routes/webhooks.fulfillments_create.jsx
@@ -1,0 +1,9 @@
+import { authenticate } from "../shopify.server";
+import { sendFulfillmentNotification } from "../whatsapp.server";
+
+export const action = async ({ request }) => {
+  const { shop } = await authenticate.webhook(request);
+  const payload = await request.json();
+  await sendFulfillmentNotification(shop, payload);
+  return new Response();
+};

--- a/app/routes/webhooks.orders_create.jsx
+++ b/app/routes/webhooks.orders_create.jsx
@@ -1,0 +1,9 @@
+import { authenticate } from "../shopify.server";
+import { sendOrderNotification } from "../whatsapp.server";
+
+export const action = async ({ request }) => {
+  const { shop } = await authenticate.webhook(request);
+  const payload = await request.json();
+  await sendOrderNotification(shop, payload);
+  return new Response();
+};

--- a/app/whatsapp.server.js
+++ b/app/whatsapp.server.js
@@ -1,0 +1,42 @@
+import prisma from "./db.server";
+
+export async function sendWhatsAppMessage({ shop, phone, message }) {
+  const config = await prisma.whatsAppConfig.findUnique({ where: { shop } });
+  if (!config || !config.enabled) return;
+
+  const url = `https://graph.facebook.com/v18.0/${config.phoneNumberId}/messages`;
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.token}`,
+    },
+    body: JSON.stringify({
+      messaging_product: "whatsapp",
+      to: phone,
+      type: "text",
+      text: { body: message },
+    }),
+  });
+}
+
+export async function sendOrderNotification(shop, order) {
+  const phone = order.phone || order.customer?.phone;
+  if (!phone) return;
+  await sendWhatsAppMessage({
+    shop,
+    phone,
+    message: `Your order ${order.name} was placed successfully.`,
+  });
+}
+
+export async function sendFulfillmentNotification(shop, fulfillment) {
+  const phone =
+    fulfillment.order?.phone || fulfillment.order?.customer?.phone;
+  if (!phone) return;
+  await sendWhatsAppMessage({
+    shop,
+    phone,
+    message: `Your order ${fulfillment.order?.name} has been fulfilled.`,
+  });
+}

--- a/prisma/migrations/20250715060700_add_whatsapp_config/migration.sql
+++ b/prisma/migrations/20250715060700_add_whatsapp_config/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "WhatsAppConfig" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "shop" TEXT NOT NULL,
+    "phoneNumberId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    CONSTRAINT "WhatsAppConfig_shop_key" UNIQUE ("shop")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,3 +30,11 @@ model Session {
   collaborator  Boolean?  @default(false)
   emailVerified Boolean?  @default(false)
 }
+
+model WhatsAppConfig {
+  id            Int     @id @default(autoincrement())
+  shop          String  @unique
+  phoneNumberId String
+  token         String
+  enabled       Boolean @default(true)
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -21,6 +21,14 @@ api_version = "2025-07"
   topics = [ "app/scopes_update" ]
   uri = "/webhooks/app/scopes_update"
 
+  [[webhooks.subscriptions]]
+  topics = [ "orders/create" ]
+  uri = "/webhooks/orders_create"
+
+  [[webhooks.subscriptions]]
+  topics = [ "fulfillments/create" ]
+  uri = "/webhooks/fulfillments_create"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
 scopes = "write_products"


### PR DESCRIPTION
## Summary
- add link to the new Settings page
- create Settings page to save WhatsApp token and phone number
- register order and fulfillment webhooks
- add WhatsApp helper and webhooks to send notifications
- create database table and migration for storing per shop WhatsApp credentials

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6875efbab5f483219717d39b2e7b3465